### PR TITLE
Rewrite main.rs and keysdone.rs (50% done with TODO checklist)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.39"
-dotenv = "0.15.0"
-poise = "0.6.1"
+chrono = "0.4"
+poise = { version = "0.6.1", features = ["collector"] }
 reqwest = { version = "0.12.7", features = ["json"] }
-serde = "1.0.208"
 serde_json = "1.0.128"
 serde_yaml = "0.9.34"
 tokio = { version = "1.39.2", features = ["rt-multi-thread"] }
+tracing = "0.1.41"
+tracing-subscriber =  { version = "0.3.19", features = ["chrono", "env-filter"] }

--- a/build.sh
+++ b/build.sh
@@ -1,30 +1,67 @@
 #!/usr/bin/bash
 
 # Update code
-git fetch && git pull
+sync_repo() {
+  git fetch && git pull
+}
 
+
+# Stage 1:
 # Build management
+build() {
+  # build and compile with cargo
+  cargo build --release
 
-cargo build --release
+  # build dockerfile
+  docker build \
+    --tag shodo/sg_assist:main \
+    .
+}
 
-# build dockerfile
-docker build \
-  --tag shodo/sg_assist:main \
-  .
-
-
-
+# Stage 2:
 # Container management
-
-# Ignore error if container doesn't exist
-docker rm -f sg_app 2>/dev/null  
-# Assumes .env has DISCORD_TOKEN=... and WOWAUDIT_TOKEN=...
-source .env 
-# Start sg_app
-docker run --name sg_app -itd --restart always \
-  -e DISCORD_TOKEN="$DISCORD_TOKEN" \
-  -e WOWAUDIT_TOKEN="$WOWAUDIT_TOKEN" \
-  shodo/sg_assist:main
+start_container() {
+  # Ignore error if container doesn't exist
+  docker rm -f sg_app 2>/dev/null  
+  # Assumes .env has DISCORD_TOKEN=... and WOWAUDIT_TOKEN=...
+  source .env 
+  # Start sg_app
+  docker run --name sg_app -itd --restart always \
+    -e DISCORD_TOKEN="$DISCORD_TOKEN" \
+    -e WOWAUDIT_TOKEN="$WOWAUDIT_TOKEN" \
+    shodo/sg_assist:main
+}
 
 # Watch initial logs
-timeout --foreground 30 watch -n 1 docker ps
+watch_docker_start() {
+  timeout --foreground 30 watch -n 1 docker ps
+}
+
+# Development Workflow
+start_dev() {
+  build
+  # Ignore error if container doesn't exist
+  docker rm -f sg_app 2>/dev/null  
+  # Assumes .env has DISCORD_TOKEN=... and WOWAUDIT_TOKEN=...
+  source .env 
+  # Start sg_app
+  docker run --name sg_app -itd --restart always \
+    -e DISCORD_TOKEN="$DISCORD_TOKEN" \
+    -e WOWAUDIT_TOKEN="$WOWAUDIT_TOKEN" \
+    -e RUST_LOG=trace \
+    shodo/sg_assist:main
+  clear
+  echo "Attaching to container. Use ctrl-c to exit..."
+  docker attach --detach-keys="ctrl-c" sg_app
+}
+
+
+if [ "$1" == "--dev" ]; then
+  echo "Start Development Workflow"
+  start_dev
+else
+  echo "Starting Default Build"
+  build
+  start_container
+  watch_docker_start
+fi

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ start_container() {
   docker run --name sg_app -itd --restart always \
     -e DISCORD_TOKEN="$DISCORD_TOKEN" \
     -e WOWAUDIT_TOKEN="$WOWAUDIT_TOKEN" \
+    -e WOWAUDIT_TOKEN_1="$WOWAUDIT_TOKEN_1" \
     shodo/sg_assist:main
 }
 
@@ -48,7 +49,8 @@ start_dev() {
   docker run --name sg_app -itd --restart always \
     -e DISCORD_TOKEN="$DISCORD_TOKEN" \
     -e WOWAUDIT_TOKEN="$WOWAUDIT_TOKEN" \
-    -e RUST_LOG=trace \
+    -e WOWAUDIT_TOKEN_1="$WOWAUDIT_TOKEN_1" \
+    -e RUST_LOG=debug \
     shodo/sg_assist:main
   clear
   echo "Attaching to container. Use ctrl-c to exit..."

--- a/src/commands/keysdone.rs
+++ b/src/commands/keysdone.rs
@@ -4,6 +4,7 @@ use reqwest;
 use serde_json::Value;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
+use crate::config;
 
 
 
@@ -45,9 +46,9 @@ pub async fn paginate<U: std::marker::Sync, E>(
     let mut current_page = 0;
     let mut current_pages = pages.clone(); // Make a mutable copy of pages
 
-    // Interaction collector with a 30-minute timeout
+    // Interaction collector with a 24-hour timeout
     if let Err(_timeout) = tokio::time::timeout(
-        std::time::Duration::from_secs(3600),
+        std::time::Duration::from_secs(86400),
         async {
             while let Some(press) = serenity::ComponentInteractionCollector::new(&ctx)
                 .filter(move |press| press.data.custom_id.starts_with(&ctx_id.to_string()))
@@ -149,16 +150,35 @@ async fn fetch_period_id() -> Result<Value, reqwest::Error> {
 
 // Fetch WoWAudit Roster Mythic+ Data
 async fn fetch_character_data() -> Result<Value, reqwest::Error> {
-    let token = std::env::var("WOWAUDIT_TOKEN").expect("missing WOWAUDIT_TOKEN");
     let client = reqwest::Client::new();
-    let response = client
-        .get("https://www.wowaudit.com/v1/historical_data")
-        .header("Authorization", token)
-        .send()
-        .await?
-        .json::<Value>()
-        .await?;
-    Ok(response)
+    let endpoint = "https://www.wowaudit.com/v1/historical_data";
+    
+    let request_1 = client
+        .get(endpoint)
+        .header("Authorization", config::team_1());
+
+    let request_2 = client
+        .get(endpoint)
+        .header("Authorization", config::team_2());
+
+    let (response_1, response_2) = tokio::join!(
+        request_1.send(),
+        request_2.send()
+    );
+
+    let json_1 = response_1?.json::<Value>().await?;
+    let json_2 = response_2?.json::<Value>().await?;
+    
+    let mut combined = Value::Null;
+    if let Some(mut mains) = json_1["characters"].as_array().cloned() {
+        if let Some(alts) = json_2["characters"].as_array()  {
+            mains.extend(alts.clone());
+            combined = serde_json::json!({ "characters": mains });
+        }
+    }
+
+    Ok(combined)
+
 }
 
 // Function to generate pages from data

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,28 @@
+use std::sync::OnceLock;
+use std::env;
+
+
+pub fn discord_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        env::var("DISCORD_TOKEN").expect("Missing WOWAUDIT_TOKEN")
+    })
+}
+
+
+
+pub fn team_1() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        env::var("WOWAUDIT_TOKEN").expect("Missing WOWAUDIT_TOKEN")
+    })
+}
+
+pub fn team_2() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        env::var("WOWAUDIT_TOKEN_1").expect("Missing WOWAUDIT_TOKEN")
+    })
+}
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,69 @@
 use poise::serenity_prelude as serenity;
 
 mod commands;
-use commands::*;
 
-struct Data {} // User data, which is stored and accessible in all command invocations
+pub struct Data {} // User data, which is stored and accessible in all command invocations
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;
 
+
+async fn on_error(error: poise::FrameworkError<'_, Data, Error>) {
+    match error {
+        poise::FrameworkError::Setup { error, .. } => panic!("Failed to start bot: {:?}", error),
+        poise::FrameworkError::Command { error, ctx, .. } => {
+            println!("Error in command `{}`: {:?}", ctx.command().name, error,);
+        }
+        error => poise::builtins::on_error(error).await.unwrap(), 
+    }
+}
+
+
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .compact()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder().with_default_directive(tracing::Level::INFO.into()).from_env_lossy(),
+        )
+        .with_target(true)
+        .init();
+
+
+
+    let options = poise::FrameworkOptions {
+        commands: vec![
+                commands::updatesim(), commands::roster(), 
+                commands::mykeys(), commands::vault(), 
+                commands::keysdone(), commands::help(),
+        ],
+        on_error: |error| Box::pin(on_error(error)),
+        ..Default::default()
+    };
+
+
+    let framework = poise::Framework::builder()
+        .setup(move |ctx, _ready, framework| {
+            Box::pin(async move {
+                println!("Logged in as {}", _ready.user.name);
+                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
+                Ok(Data{
+
+                })
+            })
+        })
+        .options(options)
+        .build();
+    
+
     let token = std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN");
+
     let intents = serenity::GatewayIntents::non_privileged() 
         | serenity::GatewayIntents::MESSAGE_CONTENT
         | serenity::GatewayIntents::DIRECT_MESSAGES
         | serenity::GatewayIntents::GUILD_MESSAGES;
 
-    let framework = poise::Framework::builder()
-        .options(poise::FrameworkOptions {
-            commands: vec![updatesim(), roster(), mykeys(), vault(), keysdone(), help()], 
-            ..Default::default()
-        })
-        .setup(|ctx, _ready, framework| {
-            Box::pin(async move {
-                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
-            })
-        })
-        .build();
-
+ 
     let client = serenity::ClientBuilder::new(token, intents)
         .framework(framework)
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
 use poise::serenity_prelude as serenity;
 
-mod commands;
+mod commands; // all command logic stored here
+mod config; // all tokens are configured here
 
 pub struct Data {} // User data, which is stored and accessible in all command invocations
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;
+
+
 
 
 async fn on_error(error: poise::FrameworkError<'_, Data, Error>) {
@@ -56,15 +59,13 @@ async fn main() {
         .build();
     
 
-    let token = std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN");
-
     let intents = serenity::GatewayIntents::non_privileged() 
         | serenity::GatewayIntents::MESSAGE_CONTENT
         | serenity::GatewayIntents::DIRECT_MESSAGES
         | serenity::GatewayIntents::GUILD_MESSAGES;
 
  
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(config::discord_token(), intents)
         .framework(framework)
         .await;
     client.unwrap().start().await.unwrap();


### PR DESCRIPTION
added tracing + tracing_subscriber crates

/keysdone now makes 2 calls to wowaudit api
 - merge data from 2 separate teams defined on Wowaudit.com
 - this command is being reworked still
 - delete embeded message after 24 hours instead of 30min.

- [x] Get data from multiple teams
- [x] Set alias/name and bind multiple characters data to alias/name
- [x] Set and read env vars one time instead of each api request
- [ ] use structs to parse json data instead of directly interacting with the objects
- [ ] move pagination logic to separate file
- [ ] fix bug with command not responding after some time 